### PR TITLE
Fix audio sync issue

### DIFF
--- a/Source/MillicastPlayer/Private/Components/MillicastSubscriberComponent.cpp
+++ b/Source/MillicastPlayer/Private/Components/MillicastSubscriberComponent.cpp
@@ -35,6 +35,11 @@ UMillicastSubscriberComponent::UMillicastSubscriberComponent(const FObjectInitia
 	PeerConnection = nullptr;
 }
 
+UMillicastSubscriberComponent::~UMillicastSubscriberComponent()
+{
+    Unsubscribe();
+}
+
 /**
 	Initialize this component with the media source required for receiving Millicast audio, video.
 	Returns false, if the MediaSource is already been set. This is usually the case when this component is

--- a/Source/MillicastPlayer/Private/WebRTC/AudioDeviceModule.cpp
+++ b/Source/MillicastPlayer/Private/WebRTC/AudioDeviceModule.cpp
@@ -29,7 +29,7 @@ void FAudioDeviceModule::InitSoundWave()
 	SoundStreaming->SoundGroup = SOUNDGROUP_Voice;
 	SoundStreaming->bLooping = true;
 
-	if (AudioComponent == nullptr) 
+	if (AudioComponent == nullptr)
 	{
 		auto AudioDevice = GEngine->GetMainAudioDevice();
 		AudioComponent = AudioDevice->CreateComponent(SoundStreaming);
@@ -299,6 +299,10 @@ void FAudioDeviceModule::PullAudioData()
 	AudioCallback->NeedMorePlayData(kNumberSamples, sizeof(Sample), kNumberOfChannels,
 		kSamplesPerSecond, AudioBuffer, out, &elapsed, &ntp);
 
-	SoundStreaming->QueueAudio(AudioBuffer, kNumberSamples * kNumberBytesPerSample);
+    // Before the stream actually started playing, elapsed == -1 and all samples are silent. Don't queue those
+    if (elapsed >= 0)
+    {
+        SoundStreaming->QueueAudio(AudioBuffer, kNumberSamples * kNumberBytesPerSample);
+    }
 }
 

--- a/Source/MillicastPlayer/Private/WebRTC/PeerConnection.cpp
+++ b/Source/MillicastPlayer/Private/WebRTC/PeerConnection.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include "AudioDeviceModule.h"
+#include "MillicastPlayerPrivate.h"
 
 rtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> FWebRTCPeerConnection::PeerConnectionFactory = nullptr;
 TUniquePtr<rtc::Thread> FWebRTCPeerConnection::SignalingThread = nullptr;
@@ -55,7 +56,7 @@ webrtc::PeerConnectionInterface::RTCConfiguration FWebRTCPeerConnection::GetDefa
 
 	return Config;
 }
-  
+
 FWebRTCPeerConnection* FWebRTCPeerConnection::Create(const FRTCConfig& Config)
 {
 	if(PeerConnectionFactory == nullptr)

--- a/Source/MillicastPlayer/Public/MillicastSubscriberComponent.h
+++ b/Source/MillicastPlayer/Public/MillicastSubscriberComponent.h
@@ -30,6 +30,8 @@ private:
 	UMillicastMediaSource* MillicastMediaSource = nullptr;
 
 public:
+    virtual ~UMillicastSubscriberComponent() override;
+
 	/**
 		Initialize this component with the media source required for receiving NDI audio, video, and metadata.
 		Returns false, if the MediaSource is already been set. This is usually the case when this component is


### PR DESCRIPTION
(Second attempt)

This fixes an audio sync issue where the plugin would start to queue empty samples before the audio stream had started playing which can be detected by checking the elapsed variable. The symptom on my end was that the first time I started in editor, sound was in sync. Afterwards it would always have ~15 secs of silence and then be out of sync. Note that we use a custom audio integration (Wwise) but the symptom and fix should be the same for the default one.

Also fixed a memory leak