### PR TITLE
Defer removal of VideoConsumers

### DIFF
--- a/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
+++ b/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
@@ -26,7 +26,7 @@ void UMillicastVideoTrackImpl::OnFrame(const webrtc::VideoFrame& VideoFrame)
 	}
 
 	webrtc::ConvertFromI420(VideoFrame, WEBRTC_PIXEL_FORMAT, 0, Buffer.GetData());
-	TArray<TWeakInterfacePtr<IMillicastExternalAudioConsumer>> removals;  //Track the AudioConsumers to clean up
+	TArray<TWeakInterfacePtr<IMillicastVideoConsumer>> removals;  //Track the AudioConsumers to clean up
 
 	for (auto& consumer : VideoConsumers)
 	{

--- a/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
+++ b/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
@@ -26,6 +26,7 @@ void UMillicastVideoTrackImpl::OnFrame(const webrtc::VideoFrame& VideoFrame)
 	}
 
 	webrtc::ConvertFromI420(VideoFrame, WEBRTC_PIXEL_FORMAT, 0, Buffer.GetData());
+	TArray<TWeakInterfacePtr<IMillicastExternalAudioConsumer>> removals;  //Track the AudioConsumers to clean up
 
 	for (auto& consumer : VideoConsumers)
 	{
@@ -35,8 +36,13 @@ void UMillicastVideoTrackImpl::OnFrame(const webrtc::VideoFrame& VideoFrame)
 		}
 		else
 		{
-			VideoConsumers.Remove(consumer);
+			removals.Add(consumer);
 		}
+	}
+
+	for (auto& consumer : removals)
+	{
+		VideoConsumers.Remove(consumer);
 	}
 }
 


### PR DESCRIPTION
Removal of consumers that no longer exist is differed until after the processing loop completes to avoid modifying the array of consumers during processing.