### PR TITLE
Remove PLATFORM_XBOXONE

### DIFF
--- a/Source/MillicastPlayer/Private/PCH.h
+++ b/Source/MillicastPlayer/Private/PCH.h
@@ -49,7 +49,7 @@
 #include "Engine/Engine.h"
 #include "Framework/Application/SlateUser.h"
 
-#if PLATFORM_WINDOWS || PLATFORM_XBOXONE
+#if PLATFORM_WINDOWS
 #include "Windows/WindowsPlatformMisc.h"
 #elif PLATFORM_LINUX
 #include "Linux/LinuxPlatformMisc.h"


### PR DESCRIPTION
Since we don't officially support XBox One remove the check for PLATFORM_XBOXONE.