### PR TITLE
Fix crash if no HTTPResponse is set

### DIFF
--- a/Source/MillicastPlayer/Private/Components/MillicastDirectorComponent.cpp
+++ b/Source/MillicastPlayer/Private/Components/MillicastDirectorComponent.cpp
@@ -159,11 +159,16 @@ bool UMillicastDirectorComponent::Authenticate()
 		{
 			ParseDirectorResponse(Response);
 		}
-		else
+		else if (Response)
 		{
 			UE_LOG(LogMillicastPlayer, Error, TEXT("Director HTTP request failed %d %s"), Response->GetResponseCode(), *Response->GetContentType());
 			FString ErrorMsg = Response->GetContentAsString();
 			OnAuthenticationFailure.Broadcast(Response->GetResponseCode(), ErrorMsg);
+		}
+		else
+		{
+		    UE_LOG(LogMillicastPlayer, Error, TEXT("Director HTTP request failed without a response"));
+			OnAuthenticationFailure.Broadcast(-1, TEXT("No response"));
 		}
 	});
 

--- a/Source/MillicastPlayer/Private/Components/MillicastSubscriberComponent.cpp
+++ b/Source/MillicastPlayer/Private/Components/MillicastSubscriberComponent.cpp
@@ -5,6 +5,7 @@
 
 #include <string>
 
+#include "Async/Async.h"
 #include "Dom/JsonObject.h"
 
 #include "Serialization/JsonReader.h"

--- a/Source/MillicastPlayer/Private/Media/MillicastMediaSource.cpp
+++ b/Source/MillicastPlayer/Private/Media/MillicastMediaSource.cpp
@@ -6,6 +6,7 @@
 #include <api/video/i420_buffer.h>
 #include <common_video/libyuv/include/webrtc_libyuv.h>
 
+#include "Async/Async.h"
 #include <RenderTargetPool.h>
 
 UMillicastMediaSource::UMillicastMediaSource()
@@ -58,7 +59,7 @@ FString UMillicastMediaSource::GetMediaOption(const FName& Key, const FString& D
 
 bool UMillicastMediaSource::HasMediaOption(const FName& Key) const
 {
-	if (Key == MillicastPlayerOption::StreamName || 
+	if (Key == MillicastPlayerOption::StreamName ||
 		Key == MillicastPlayerOption::AccountId ||
 		Key == MillicastPlayerOption::SubscribeToken)
 	{
@@ -79,7 +80,7 @@ FString UMillicastMediaSource::GetUrl() const
 
 bool UMillicastMediaSource::Validate() const
 {
-	return !StreamName.IsEmpty() && !AccountId.IsEmpty() && 
+	return !StreamName.IsEmpty() && !AccountId.IsEmpty() &&
 		(!bUseSubscribeToken || (bUseSubscribeToken && !SubscribeToken.IsEmpty()));
 }
 

--- a/Source/MillicastPlayer/Private/Media/MillicastTexture2DPlayer.cpp
+++ b/Source/MillicastPlayer/Private/Media/MillicastTexture2DPlayer.cpp
@@ -1,6 +1,7 @@
 // Copyright Millciast 2022. All Rights Reserved.
 
 #include "MillicastTexture2DPlayer.h"
+#include "Async/Async.h"
 
 #include <RenderTargetPool.h>
 

--- a/Source/MillicastPlayer/Private/WebRTC/AudioDeviceModule.cpp
+++ b/Source/MillicastPlayer/Private/WebRTC/AudioDeviceModule.cpp
@@ -1,6 +1,7 @@
 // Copyright CoSMoSoftware 2021. All Rights Reserved.
 
 #include "AudioDeviceModule.h"
+#include "Async/Async.h"
 #include "MillicastPlayerPrivate.h"
 
 namespace MillicastPlayer

--- a/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
+++ b/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
@@ -6,6 +6,7 @@
 #include "Async/Async.h"
 #include "MillicastPlayerPrivate.h"
 #include "PeerConnection.h"
+#include "SampleBuffer.h"
 #include "WebRTC/AudioDeviceModule.h"
 
 #define WEAK_CAPTURE WeakThis = TWeakObjectPtr<UMillicastVideoTrackImpl>(this)

--- a/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
+++ b/Source/MillicastPlayer/Private/WebRTC/MillicastMediaTracks.cpp
@@ -3,6 +3,7 @@
 #include <api/video/i420_buffer.h>
 #include <common_video/libyuv/include/webrtc_libyuv.h>
 
+#include "Async/Async.h"
 #include "MillicastPlayerPrivate.h"
 #include "PeerConnection.h"
 #include "WebRTC/AudioDeviceModule.h"
@@ -15,7 +16,7 @@ void UMillicastVideoTrackImpl::OnFrame(const webrtc::VideoFrame& VideoFrame)
 {
 	AsyncTask(ENamedThreads::GameThread, [WEAK_CAPTURE, VideoFrame]() {
 		constexpr auto WEBRTC_PIXEL_FORMAT = webrtc::VideoType::kARGB;
-		
+
 		if (!WeakThis.IsValid())
 		{
 			return;
@@ -146,7 +147,7 @@ void UMillicastVideoTrackImpl::RemoveConsumer(TScriptInterface<IMillicastVideoCo
 
 /** Audio */
 
-void UMillicastAudioTrackImpl::OnData(const void* AudioData, int BitPerSample, int SampleRate, size_t NumberOfChannels, 
+void UMillicastAudioTrackImpl::OnData(const void* AudioData, int BitPerSample, int SampleRate, size_t NumberOfChannels,
 	size_t NumberOfFrames)
 {
 	FScopeLock Lock(&CriticalSection);

--- a/Source/MillicastPlayer/Public/MillicastAudioActor.h
+++ b/Source/MillicastPlayer/Public/MillicastAudioActor.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
 #include "UObject/ObjectMacros.h"
 #include "IMillicastExternalAudioConsumer.h"
 
@@ -18,7 +19,7 @@ UCLASS(BlueprintType, Blueprintable, Category = "Millicast Player", META = (Disp
 class MILLICASTPLAYER_API AMillicastAudioActor : public AActor, public IMillicastExternalAudioConsumer
 {
     GENERATED_BODY()
-        
+
 public:
     AMillicastAudioActor(const FObjectInitializer& ObjectInitializer);
     ~AMillicastAudioActor() noexcept;
@@ -30,7 +31,7 @@ public:
     // IMillicastExternalAudioConsumer
     virtual FMillicastAudioParameters GetAudioParameters() const override;
     void UpdateAudioParameters(FMillicastAudioParameters Parameters) noexcept override;
-    
+
     /**
     * Initialize this actor and create the SoundWaveProcedural object.
     */

--- a/Source/MillicastPlayer/Public/MillicastDirectorComponent.h
+++ b/Source/MillicastPlayer/Public/MillicastDirectorComponent.h
@@ -62,7 +62,7 @@ public:
 	FMillicastDirectorComponentAuthenticationFailure OnAuthenticationFailure;
 
 private:
-	void ParseIceServers(const TArray<TSharedPtr<FJsonValue>>& IceServersField,
+	void ParseIceServers(const TArray<TSharedPtr<class FJsonValue>>& IceServersField,
 		FMillicastSignalingData& SignalingData);
 	void ParseDirectorResponse(TSharedPtr<IHttpResponse, ESPMode::ThreadSafe> Response);
 };

--- a/Source/MillicastPlayer/Public/MillicastMediaSource.h
+++ b/Source/MillicastPlayer/Public/MillicastMediaSource.h
@@ -6,6 +6,7 @@
 #include "StreamMediaSource.h"
 #include "MillicastMediaTexture2D.h"
 #include "MillicastSignalingData.h"
+#include "RendererInterface.h"
 
 #include "api/media_stream_interface.h"
 


### PR DESCRIPTION
In Unreal it's not guaranteed that the `FHttpResponsePtr` is valid when handling an HTTP request. In the `bConnectedSuccessfully` case it's fine, but otherwise you can crash