### PR TITLE
Include & category fixes

### DIFF
--- a/Source/MillicastPlayer/Private/WebRTC/PlayerStats.h
+++ b/Source/MillicastPlayer/Private/WebRTC/PlayerStats.h
@@ -11,11 +11,12 @@
 
 class FCanvas;
 class FCommonViewportClient;
-class FPlayerStatsCollector;
 class FViewport;
 
 namespace Millicast::Player
 {
+	class FPlayerStatsCollector;
+
 	/*
 	 * Some basic performance stats about how the publisher is running, e.g. how long capture/encode takes.
 	 * Stats are drawn to screen for now as it is useful to observe them in realtime.
@@ -59,7 +60,7 @@ namespace Millicast::Player
 		int32 OnRenderStats(UWorld* World, FViewport* Viewport, FCanvas* Canvas, int32 X, int32 Y, const FVector* ViewLocation, const FRotator* ViewRotation);
 
 		void RegisterEngineHooks();
-	
+
 	private:
 		bool bRendering = false;
 		bool bHasRegisteredEngineStats = false;

--- a/Source/MillicastPlayer/Public/Components/MillicastSubscriberComponent.h
+++ b/Source/MillicastPlayer/Public/Components/MillicastSubscriberComponent.h
@@ -6,6 +6,7 @@
 #include "IMillicastMediaTrack.h"
 #include "MillicastSignalingData.h"
 #include "MillicastMediaSource.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 #include "MillicastSubscriberComponent.generated.h"
 
@@ -108,7 +109,7 @@ private:
 	UPROPERTY(EditDefaultsOnly, Category = "Properties",
 		META = (DisplayName = "Extract Frame Metadata", AllowPrivateAccess = true))
 	bool bUseFrameTransformer = false;
-	
+
 private:
 	void SendCommand(const FString& Name, TSharedPtr<FJsonObject> Data);
 
@@ -159,7 +160,7 @@ public:
 	*/
 	Millicast::Player::FPlayerStatsCollector* GetStatsCollector();
 #endif
-	
+
 	/*
 		Returns if the subscriber is currently subscribed or not.
 	*/
@@ -204,7 +205,7 @@ public:
 	/** Called when the connection is interrupted. */
 	UPROPERTY(BlueprintAssignable, Category = "Components|Activation")
 	FMillicastSubscriberComponentDisconnected OnDisconnected;
-	
+
 	/** Called when the stream is no longer available */
 	UPROPERTY(BlueprintAssignable, Category = "Components|Activation")
 	FMillicastSubscriberComponentStopped OnStopped;
@@ -265,7 +266,7 @@ private:
 
 	UPROPERTY()
 	UMillicastDirectorComponent* CachedDirectorComponent = nullptr;
-	
+
 	UPROPERTY()
 	TArray<UMillicastAudioTrack*> AudioTracks;
 

--- a/Source/MillicastPlayer/Public/Subsystems/MillicastAudioSubsystem.h
+++ b/Source/MillicastPlayer/Public/Subsystems/MillicastAudioSubsystem.h
@@ -16,19 +16,19 @@ UCLASS()
 class MILLICASTPLAYER_API UMillicastAudioSubsystem : public UGameInstanceSubsystem
 {
     GENERATED_BODY()
-    
+
 public:
     //void Initialize(FSubsystemCollectionBase& Collection) override;
     //void Deinitialize() override;
 
-    UFUNCTION(BlueprintCallable)
+    UFUNCTION(BlueprintCallable, Category = "MillicastPlayer")
     void Register(UAudioComponent* Component);
 
-    UFUNCTION(BlueprintCallable)
+    UFUNCTION(BlueprintCallable, Category = "MillicastPlayer")
     void Unregister(UAudioComponent* Component);
 
     UMillicastAudioInstance* GetInstance(UAudioComponent* Component);
-    
+
 private:
     UPROPERTY()
     TArray<UMillicastAudioInstance*> AudioInstances;

--- a/Source/MillicastPlayer/Public/WebRTC/PlayerStatsCollector.h
+++ b/Source/MillicastPlayer/Public/WebRTC/PlayerStatsCollector.h
@@ -1,5 +1,4 @@
 // Copyright Millicast 2022. All Rights Reserved.
-
 #pragma once
 
 #include "Runtime/Launch/Resources/Version.h"
@@ -20,7 +19,7 @@ namespace Millicast::Player
 	public:
 		DECLARE_EVENT_OneParam(FPlayerStatsCollector, FPlayerStatsCollectorOnStats, const rtc::scoped_refptr<const webrtc::RTCStatsReport>& /*Report*/);
 		FPlayerStatsCollectorOnStats OnStats;
-		
+
 	public:
 		FPlayerStatsCollector(class FWebRTCPeerConnection* InPeerConnection);
 		~FPlayerStatsCollector();
@@ -29,7 +28,7 @@ namespace Millicast::Player
 
 		const FString& GetClusterId() const;
 		const FString& GetServerId() const;
-		
+
 		double Rtt; // ms
 		size_t Width; // px
 		size_t Height; // px
@@ -70,7 +69,7 @@ namespace Millicast::Player
 
 		// Begin RTCStatsCollectorCallback interface
 		void OnStatsDelivered(const rtc::scoped_refptr<const webrtc::RTCStatsReport>& report) override;
-	
+
 	private:
 		FWebRTCPeerConnection* PeerConnection;
 		mutable int32 RefCount;


### PR DESCRIPTION
Some more include fixes. Also, if the plugin is installed as an engine plugin (which it is in our case), all BP exposed functions and properties must have a category assigned.