### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ If that is the case, create an empty C++ class in your project. This will force 
 
 If you want to run the plugin on Mac, or have H264 decoding support, you will need to use our webrtc library instead of the Unreal one. You need to add it directly into your project, in the plugin ThirdParty.
 
-Download the ``ThirdParty.zip`` file that you can find in the release assets of the latest github release.
+Download the ``ThirdParty.zip`` file that you can find in the release assets at [this GitHub release](https://github.com/millicast/millicast-publisher-unreal-engine-plugin/releases/tag/1.8.0).
+
 
 Then, extract it and move the ``ThirdParty`` folder into the ``Source`` folder of the plugins.
 After that, you should be able to build and run the plugin using our WebRTC library. 


### PR DESCRIPTION
Due to an issue with the ThirdParty.zip, a link error occurred during the H.264 build in a Windows environment.

After consulting with Dolby.io Support, I was directed to the link provided. Could you please update the README to reflect this information?